### PR TITLE
feat: show CI status

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2,12 +2,13 @@ package types
 
 // PR represents a pull request
 type PR struct {
-	Number  int    `json:"number"`
-	Title   string `json:"title"`
-	Author  string `json:"author"`
-	Repo    string `json:"repo"` // OWNER/REPO format
-	URL     string `json:"url"`
-	HeadSHA string `json:"-"` // For CI status checks
+	Number   int    `json:"number"`
+	Title    string `json:"title"`
+	Author   string `json:"author"`
+	Repo     string `json:"repo"` // OWNER/REPO format
+	URL      string `json:"url"`
+	HeadSHA  string `json:"-"`         // For CI status checks
+	CIStatus string `json:"ci_status"` // CI status: success, pending, failure, or empty
 }
 
 // Group represents a collection of PRs for the same package@version


### PR DESCRIPTION
resolve #2 

This pull request introduces concurrent fetching and display of CI status for pull requests, and enhances the TUI (terminal UI) to show and filter by CI status. The main changes include updating the data model to store CI status, concurrently fetching this status for each PR, and improving the UI to visualize and filter PRs based on their CI results.

**Concurrent CI status fetching and model updates:**
- The `types.PR` struct now includes a `CIStatus` field to store the CI state for each pull request.
- The `SearchPRs` function in `internal/github/client.go` has been updated to fetch the HEAD SHA and CI status for each PR concurrently using a worker pool, improving performance and ensuring each PR's CI status is available for the UI. [[1]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deL71-R108) [[2]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR8)

**TUI enhancements for CI status:**
- New styles for CI status indicators (success, pending, failure, unknown) have been added using `lipgloss`, allowing CI status to be visually distinguished in the PR list.
- The PR list now displays a CI status icon for each PR, rendered using the new styles. [[1]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedL421-R443) [[2]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedR591-R603)
- The PR filtering logic in the TUI has been updated to allow filtering PRs by CI status, specifically showing only PRs with successful CI when the `requireChecks` option is enabled. The filter also resets the cursor and clears hidden selections when toggled. [[1]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedR332-R333) [[2]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedL582-R636)

<img width="606" height="245" alt="Screenshot 2025-10-06 at 10 44 16" src="https://github.com/user-attachments/assets/5ce546b1-d23c-4063-ac3e-e4e00bc0e0ef" />
