### PR TITLE
fix: ci status check logic

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,122 @@
+package github
+
+import "testing"
+
+func TestDeriveCIState(t *testing.T) {
+	tests := []struct {
+		name   string
+		suites checkSuiteResponse
+		status statusResponse
+		want   string
+	}{
+		{
+			name: "check suites success",
+			suites: checkSuiteResponse{
+				CheckSuites: []checkSuite{
+					{Status: "completed", Conclusion: strPtr("success")},
+				},
+			},
+			status: statusResponse{},
+			want:   "success",
+		},
+		{
+			name: "check suites failure",
+			suites: checkSuiteResponse{
+				CheckSuites: []checkSuite{
+					{Status: "completed", Conclusion: strPtr("failure")},
+				},
+			},
+			status: statusResponse{},
+			want:   "failure",
+		},
+		{
+			name: "queued suite ignored when another succeeds",
+			suites: checkSuiteResponse{
+				CheckSuites: []checkSuite{
+					{Status: "queued"},
+					{Status: "completed", Conclusion: strPtr("success")},
+				},
+			},
+			status: statusResponse{},
+			want:   "success",
+		},
+		{
+			name: "status pending overrides success",
+			suites: checkSuiteResponse{
+				CheckSuites: []checkSuite{
+					{Status: "completed", Conclusion: strPtr("success")},
+				},
+			},
+			status: statusResponse{
+				Statuses: []statusContext{
+					{State: "pending"},
+				},
+			},
+			want: "pending",
+		},
+		{
+			name: "status failure overrides suite success",
+			suites: checkSuiteResponse{
+				CheckSuites: []checkSuite{
+					{Status: "completed", Conclusion: strPtr("success")},
+				},
+			},
+			status: statusResponse{
+				Statuses: []statusContext{
+					{State: "failure"},
+				},
+			},
+			want: "failure",
+		},
+		{
+			name: "status success without suites",
+			status: statusResponse{
+				Statuses: []statusContext{
+					{State: "success"},
+				},
+			},
+			want: "success",
+		},
+		{
+			name: "status failure without suites",
+			status: statusResponse{
+				Statuses: []statusContext{
+					{State: "failure"},
+				},
+			},
+			want: "failure",
+		},
+		{
+			name: "status pending without suites",
+			status: statusResponse{
+				Statuses: []statusContext{
+					{State: "pending"},
+				},
+			},
+			want: "pending",
+		},
+		{
+			name: "suite in progress is pending",
+			suites: checkSuiteResponse{
+				CheckSuites: []checkSuite{
+					{Status: "in_progress"},
+				},
+			},
+			status: statusResponse{},
+			want:   "pending",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveCIState(tt.suites, tt.status)
+			if got != tt.want {
+				t.Fatalf("deriveCIState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
fixes #4 

This pull request refactors and improves the logic for determining the CI status of a commit in the GitHub client. The main change is the introduction of a unified function that evaluates both check suites and status contexts to derive a more accurate CI state. Additionally, comprehensive unit tests have been added to verify the new logic.

### CI status determination improvements

* Added new types (`statusResponse`, `statusContext`, `checkSuiteResponse`, `checkSuite`) to represent the structure of CI status and check suite responses, enabling more granular analysis of CI results.
* Replaced the previous logic in `GetCIStatus` with a new approach that fetches both check suite and status context data, and uses the new `deriveCIState` function to determine the overall CI state (`success`, `failure`, or `pending`). This improves reliability and correctness when interpreting CI results.
* Introduced the `deriveCIState` function, which analyzes all available check suites and status contexts to accurately compute the CI state, handling edge cases such as queued, in-progress, and mixed results.

### Testing

* Added a comprehensive unit test (`TestDeriveCIState`) in `internal/github/client_test.go` to cover various scenarios and edge cases for the new CI status derivation logic, ensuring correctness and robustness.

### Dependency update

* Imported the `slices` package to simplify array operations in the new logic.