### PR TITLE
feat: add tui mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Launch an interactive terminal UI for managing dependency PRs with:
 - `--limit` - Max PRs to fetch per repo (default: 200)
 - `--repo` / `-R` - Target repo(s), comma-separated
 - `--owner` - Target all repos in an organization
+- `--mode` - Initial execution mode: `approve`, `merge`, or `approve-and-merge` (default: `approve`)
 - `--merge-method` - Initial merge method (default: `squash`)
 - `--merge-mode` - Initial merge mode (default: `dependabot`)
 - `--require-checks` - Initial CI checks setting
@@ -147,6 +148,12 @@ gh dep --repo owner/app
 
 # Launch for entire organization with custom initial settings
 gh dep --owner myorg --merge-method rebase --merge-mode api
+
+# Start in merge mode instead of approve mode
+gh dep --repo owner/app --mode merge
+
+# Start in approve-and-merge mode
+gh dep --repo owner/app --mode approve-and-merge
 
 # Filter by label
 gh dep --repo owner/app --label dependencies

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var (
 	rootMergeMethod  string
 	rootMergeMode    string
 	rootRequireCheck bool
+	rootMode         string
 )
 
 var rootCmd = &cobra.Command{
@@ -78,8 +79,19 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Parse mode
+	mode := tui.ModeApprove // default
+	switch rootMode {
+	case "approve":
+		mode = tui.ModeApprove
+	case "merge":
+		mode = tui.ModeMerge
+	case "approve-and-merge", "both":
+		mode = tui.ModeApproveAndMerge
+	}
+
 	// Launch TUI
-	model := tui.NewModelWithExecutor(allPRs, rootMergeMethod, rootMergeMode, rootRequireCheck)
+	model := tui.NewModelWithExecutor(allPRs, rootMergeMethod, rootMergeMode, rootRequireCheck, mode)
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
@@ -98,6 +110,7 @@ func init() {
 	rootCmd.Flags().StringVar(&rootMergeMethod, "merge-method", "squash", "Merge method: merge, squash, or rebase")
 	rootCmd.Flags().StringVar(&rootMergeMode, "merge-mode", "dependabot", "Merge mode: dependabot or api")
 	rootCmd.Flags().BoolVar(&rootRequireCheck, "require-checks", false, "Require CI checks to pass (API mode only)")
+	rootCmd.Flags().StringVar(&rootMode, "mode", "approve", "Execution mode: approve, merge, or approve-and-merge (both)")
 
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(groupsCmd)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -201,7 +201,7 @@ var (
 			Foreground(lipgloss.Color("240"))
 )
 
-func NewModel(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool) *Model {
+func NewModel(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool, mode ExecutionMode) *Model {
 	ti := textinput.New()
 	ti.Placeholder = "Search PRs..."
 	ti.CharLimit = 100
@@ -211,7 +211,7 @@ func NewModel(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool)
 		filteredPRs:   prs,
 		selected:      make(map[int]bool),
 		cursor:        0,
-		mode:          ModeApprove,
+		mode:          mode,
 		view:          ViewList,
 		searchInput:   ti,
 		searching:     false,
@@ -223,8 +223,8 @@ func NewModel(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool)
 }
 
 // NewModelWithExecutor creates a new model with execution capabilities
-func NewModelWithExecutor(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool) *Model {
-	return NewModel(prs, mergeMethod, mergeMode, requireChecks)
+func NewModelWithExecutor(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool, mode ExecutionMode) *Model {
+	return NewModel(prs, mergeMethod, mergeMode, requireChecks, mode)
 }
 
 func (m *Model) Init() tea.Cmd {


### PR DESCRIPTION
This pull request adds support for specifying the initial execution mode when launching the interactive terminal UI for managing dependency PRs. Users can now choose to start in "approve", "merge", or "approve-and-merge" mode using the new `--mode` flag. The changes update both the CLI documentation and the underlying code to handle this new option.

### CLI enhancements

* Added a new `--mode` flag to the CLI, allowing users to specify the initial execution mode (`approve`, `merge`, or `approve-and-merge`). The flag is documented in `README.md`, and usage examples are provided. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R138) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R157)
* Registered the `--mode` flag in the CLI command initialization in `cmd/root.go`.

### TUI initialization updates

* Updated the TUI model initialization to accept the execution mode, allowing the UI to start in the specified mode based on the `--mode` flag. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR82-R94) [[2]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedL204-R204) [[3]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedL214-R214) [[4]](diffhunk://#diff-8f28281a6c168ae2186228c5ff4fa00c1c8e2b0d4c2c863197acffcec7363eedL226-R227)

### Internal variable changes

* Added a new `rootMode` variable to store the execution mode selected via the CLI flag.