### PR TITLE
fix(tui): require check initial flag

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -206,7 +206,7 @@ func NewModel(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool,
 	ti.Placeholder = "Search PRs..."
 	ti.CharLimit = 100
 
-	return &Model{
+	m := &Model{
 		prs:           prs,
 		filteredPRs:   prs,
 		selected:      make(map[int]bool),
@@ -220,6 +220,13 @@ func NewModel(prs []types.PR, mergeMethod, mergeMode string, requireChecks bool,
 		mergeMode:     mergeMode,
 		requireChecks: requireChecks,
 	}
+
+	// Apply initial filtering based on requireChecks
+	if requireChecks {
+		m.filterPRs()
+	}
+
+	return m
 }
 
 // NewModelWithExecutor creates a new model with execution capabilities


### PR DESCRIPTION
This pull request updates the initialization logic in the `NewModel` function within `internal/tui/model.go` to ensure that PRs are filtered according to the `requireChecks` setting immediately upon model creation. This change improves the accuracy of the initial PR list presented to users when checks are required.

Initialization and filtering improvements:

* Changed the return value in `NewModel` to use a local variable `m` instead of returning the struct directly, enabling additional setup before returning.
* Added logic to apply initial PR filtering by calling `m.filterPRs()` when `requireChecks` is true, ensuring the model starts with the correct filtered PR list.