### PR TITLE
chore(tui): return to list after execute

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -254,8 +254,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.view == ViewComplete {
-			if msg.String() == "q" || msg.String() == "enter" {
+			if msg.String() == "q" {
 				return m, tea.Quit
+			}
+			if msg.String() == "enter" || msg.String() == "esc" {
+				m.view = ViewList
+				m.executionResult = nil
+				m.selected = make(map[int]bool)
+				return m, nil
 			}
 			return m, nil
 		}
@@ -541,7 +547,7 @@ func (m *Model) renderComplete() string {
 	s.WriteString("\n")
 	s.WriteString(headerStyle.Render(fmt.Sprintf("Summary: %d succeeded, %d failed", successCount, failCount)))
 	s.WriteString("\n\n")
-	s.WriteString(helpStyle.Render("Press enter or q to exit"))
+	s.WriteString(helpStyle.Render("Press enter to return to list • q to quit"))
 
 	return s.String()
 }


### PR DESCRIPTION
This pull request updates the user interaction flow in the TUI when viewing command execution results. The changes clarify the available keyboard shortcuts and improve navigation by allowing users to return to the command list view more intuitively.

User interaction improvements:

* In the `ViewComplete` state of `func (m *Model) Update(msg tea.Msg)`, pressing `enter` or `esc` now returns the user to the command list view, resets the execution result, and clears selected items. Previously, only `q` or `enter` would quit the application.
* The help text in `func (m *Model) renderComplete()` is updated to clearly indicate that pressing `enter` returns to the list and `q` quits, improving user guidance.