### PR TITLE
feat: add archived and review-requested flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Launch an interactive terminal UI for managing dependency PRs with:
 
 - `--author` - PR author to filter (default: `dependabot[bot]`, use `any` for all)
 - `--label` - PR label to filter
+- `--review-requested` - Filter PRs by review requested from user or team (e.g., `@me` or `username`)
+- `--archived` - Include PRs from archived repositories (default: false)
 - `--limit` - Max PRs to fetch per repo (default: 200)
 - `--repo` / `-R` - Target repo(s), comma-separated
 - `--owner` - Target all repos in an organization
@@ -157,6 +159,12 @@ gh dep --repo owner/app --mode approve-and-merge
 
 # Filter by label
 gh dep --repo owner/app --label dependencies
+
+# Filter PRs where review is requested from you
+gh dep --repo owner/app --review-requested @me
+
+# Include PRs from archived repositories
+gh dep --owner myorg --archived
 ```
 
 #### `list` - List dependency PRs
@@ -169,6 +177,8 @@ gh dep list [flags]
 
 - `--label` - PR label to filter
 - `--author` - PR author to filter (default: `dependabot[bot]`, use `any` for all)
+- `--review-requested` - Filter PRs by review requested from user or team (e.g., `@me` or `username`)
+- `--archived` - Include PRs from archived repositories (default: false)
 - `--group` - Group PRs by package@version and cache results
 - `--json` - Output as JSON
 - `--limit` - Max PRs to fetch per repo (default: 200)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,13 +19,15 @@ var listCmd = &cobra.Command{
 }
 
 var (
-	listLabel  string
-	listAuthor string
-	listGroup  bool
-	listLimit  int
-	listRepo   string
-	listOwner  string
-	listJSON   bool
+	listLabel           string
+	listAuthor          string
+	listGroup           bool
+	listLimit           int
+	listRepo            string
+	listOwner           string
+	listJSON            bool
+	listReviewRequested string
+	listArchived        bool
 )
 
 func init() {
@@ -39,6 +41,8 @@ func init() {
 	listCmd.Flags().StringVar(&listLabel, "label", "", "PR label to filter")
 	listCmd.Flags().StringVar(&listAuthor, "author", "dependabot[bot]", "PR author to filter (use 'any' for all)")
 	listCmd.Flags().StringVar(&listOwner, "owner", "", "Target owner (user or org)")
+	listCmd.Flags().StringVar(&listReviewRequested, "review-requested", "", "Filter PRs by review requested from user or team (e.g., '@me' or 'username')")
+	listCmd.Flags().BoolVar(&listArchived, "archived", false, "Include PRs from archived repositories")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -56,11 +60,13 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	searchParams := github.SearchParams{
-		Owner:  rootOwner,
-		Repos:  strings.Split(repo, ","),
-		Label:  label,
-		Author: author,
-		Limit:  rootLimit,
+		Owner:           rootOwner,
+		Repos:           strings.Split(repo, ","),
+		Label:           label,
+		Author:          author,
+		Limit:           rootLimit,
+		ReviewRequested: listReviewRequested,
+		Archived:        listArchived,
 	}
 
 	allPRs, err := github.SearchPRs(searchParams)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,15 +11,17 @@ import (
 )
 
 var (
-	rootLabel        string
-	rootAuthor       string
-	rootLimit        int
-	rootRepo         string
-	rootOwner        string
-	rootMergeMethod  string
-	rootMergeMode    string
-	rootRequireCheck bool
-	rootMode         string
+	rootLabel           string
+	rootAuthor          string
+	rootLimit           int
+	rootRepo            string
+	rootOwner           string
+	rootMergeMethod     string
+	rootMergeMode       string
+	rootRequireCheck    bool
+	rootMode            string
+	rootReviewRequested string
+	rootArchived        bool
 )
 
 var rootCmd = &cobra.Command{
@@ -39,11 +41,13 @@ func Execute() error {
 
 func runRoot(cmd *cobra.Command, args []string) error {
 	searchParams := github.SearchParams{
-		Owner:  rootOwner,
-		Repos:  strings.Split(rootRepo, ","),
-		Label:  rootLabel,
-		Author: rootAuthor,
-		Limit:  rootLimit,
+		Owner:           rootOwner,
+		Repos:           strings.Split(rootRepo, ","),
+		Label:           rootLabel,
+		Author:          rootAuthor,
+		Limit:           rootLimit,
+		ReviewRequested: rootReviewRequested,
+		Archived:        rootArchived,
 	}
 
 	allPRs, err := github.SearchPRs(searchParams)
@@ -88,6 +92,8 @@ func init() {
 	rootCmd.Flags().StringVar(&rootMergeMode, "merge-mode", "dependabot", "Merge mode: dependabot or api")
 	rootCmd.Flags().BoolVar(&rootRequireCheck, "require-checks", false, "Require CI checks to pass (API mode only)")
 	rootCmd.Flags().StringVar(&rootMode, "mode", "approve", "Execution mode: approve, merge, or approve-and-merge (both)")
+	rootCmd.Flags().StringVar(&rootReviewRequested, "review-requested", "", "Filter PRs by review requested from user or team (e.g., '@me' or 'username')")
+	rootCmd.Flags().BoolVar(&rootArchived, "archived", false, "Include PRs from archived repositories")
 
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(groupsCmd)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -20,11 +20,13 @@ func GetClient() (*api.RESTClient, error) {
 }
 
 type SearchParams struct {
-	Owner  string
-	Repos  []string
-	Label  string
-	Author string
-	Limit  int
+	Owner           string
+	Repos           []string
+	Label           string
+	Author          string
+	Limit           int
+	ReviewRequested string
+	Archived        bool
 }
 
 // SearchPRs searches for PRs based on the given parameters
@@ -45,6 +47,13 @@ func SearchPRs(params SearchParams) ([]types.PR, error) {
 	}
 	if params.Author != "" && params.Author != "any" {
 		args = append(args, "--author", params.Author)
+	}
+	if params.ReviewRequested != "" {
+		args = append(args, "--review-requested", params.ReviewRequested)
+	}
+	// Only include archived repos if explicitly requested
+	if !params.Archived {
+		args = append(args, fmt.Sprintf("--archived=%t", params.Archived))
 	}
 	args = append(args, "--json", "number,title,author,url,repository")
 	if params.Limit > 0 {


### PR DESCRIPTION
This pull request adds new filtering options to the dependency PR management CLI, allowing users to filter PRs by review requests and include PRs from archived repositories. The changes update both the documentation and the CLI implementation to support these features.

### New filtering options for PR management

* Added `--review-requested` flag to filter PRs by review requests from a specific user or team, available in both the root and list commands (`cmd/root.go`, `cmd/list.go`, `internal/github/client.go`, `README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R136) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R167) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R181) [[4]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R29-R30) [[5]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R44-R45) [[6]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R68-R69) [[7]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR23-R24) [[8]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR49-R50) [[9]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR95-R96) [[10]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR28-R29) [[11]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR51-R57)
* Added `--archived` flag to include PRs from archived repositories, available in both the root and list commands (`cmd/root.go`, `cmd/list.go`, `internal/github/client.go`, `README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R136) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R167) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R181) [[4]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R29-R30) [[5]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R44-R45) [[6]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R68-R69) [[7]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR23-R24) [[8]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR49-R50) [[9]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR95-R96) [[10]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR28-R29) [[11]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR51-R57)

### Documentation updates

* Updated usage instructions and examples in `README.md` to document the new `--review-requested` and `--archived` flags. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R136) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R167) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R181)

### Internal API and flag wiring

* Extended the `SearchParams` struct and CLI flag registration to accept and pass the new filtering options through the codebase (`cmd/root.go`, `cmd/list.go`, `internal/github/client.go`). [[1]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R29-R30) [[2]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R44-R45) [[3]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R68-R69) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR23-R24) [[5]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR49-R50) [[6]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR95-R96) [[7]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR28-R29) [[8]](diffhunk://#diff-0a204c1fb91cf173cb42c775119266781b45b7f4d326b6f1524fe5fd92a094deR51-R57)