### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackchuka/gh-dep
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `go.mod` from `1.26.1` to `1.26.5`.
- Go 1.26.5 (released 2026-07-07) includes security fixes to `crypto/tls` and `os`.

## Local verification (macOS/arm64)
- `go mod tidy` — clean, no additional changes beyond the version bump
- `go test ./...` — all packages pass

```
?   github.com/jackchuka/gh-dep            [no test files]
ok  github.com/jackchuka/gh-dep/cmd        0.696s
?   github.com/jackchuka/gh-dep/internal/cache   [no test files]
?   github.com/jackchuka/gh-dep/internal/config  [no test files]
ok  github.com/jackchuka/gh-dep/internal/github  1.071s
ok  github.com/jackchuka/gh-dep/internal/parser  1.408s
?   github.com/jackchuka/gh-dep/internal/tui     [no test files]
?   github.com/jackchuka/gh-dep/internal/types   [no test files]
?   github.com/jackchuka/gh-dep/internal/ui      [no test files]
```